### PR TITLE
Refactor queries with generic table loader

### DIFF
--- a/queries.py
+++ b/queries.py
@@ -1,27 +1,53 @@
+"""Utility functions for loading data from the SQLite database used by the
+interactive app."""
+
+from __future__ import annotations
+
 import sqlite3
+from typing import Final
+
 import pandas as pd
 import streamlit as st
 
-## RFI Table
+
+DEFAULT_DB_PATH: Final[str] = "rfi.db"
+
+
 @st.cache_data
-def load_data():
-    conn = sqlite3.connect("rfi.db")
-    df = pd.read_sql_query("SELECT * FROM rfi_table", conn)
-    conn.close()
+def load_table(table_name: str, db_path: str = DEFAULT_DB_PATH) -> pd.DataFrame:
+    """Return ``table_name`` from ``db_path`` as a :class:`pandas.DataFrame`.
+
+    Parameters
+    ----------
+    table_name:
+        Name of the table to read from the SQLite database.
+    db_path:
+        Path to the SQLite database file.  Defaults to ``"rfi.db"``.
+
+    Returns
+    -------
+    pandas.DataFrame
+        The contents of ``table_name``.
+    """
+
+    with sqlite3.connect(db_path) as conn:
+        df = pd.read_sql_query(f"SELECT * FROM {table_name}", conn)
     return df
 
-## Summary Table
-@st.cache_data
-def load_summary_data():
-    conn = sqlite3.connect("rfi.db")
-    df = pd.read_sql_query("SELECT * FROM summary_table", conn)
-    conn.close()
-    return df
 
-## Transitions Table
-@st.cache_data
-def load_transitions_data():
-    conn = sqlite3.connect("rfi.db")
-    df = pd.read_sql_query("SELECT * FROM transitions_table", conn)
-    conn.close()
-    return df
+def load_data(db_path: str = DEFAULT_DB_PATH) -> pd.DataFrame:
+    """Load the ``rfi_table`` from the database."""
+
+    return load_table("rfi_table", db_path=db_path)
+
+
+def load_summary_data(db_path: str = DEFAULT_DB_PATH) -> pd.DataFrame:
+    """Load the ``summary_table`` from the database."""
+
+    return load_table("summary_table", db_path=db_path)
+
+
+def load_transitions_data(db_path: str = DEFAULT_DB_PATH) -> pd.DataFrame:
+    """Load the ``transitions_table`` from the database."""
+
+    return load_table("transitions_table", db_path=db_path)


### PR DESCRIPTION
## Summary
- refactor repeated code for loading data tables
- provide a single load_table helper
- add docstrings and typing
- support configurable DB path

## Testing
- `python -m py_compile queries.py`


------
https://chatgpt.com/codex/tasks/task_e_685d82ecdf84832d90331435d6fee30c