### PR TITLE
Add persistent score column to transitions table

### DIFF
--- a/create_db.py
+++ b/create_db.py
@@ -13,6 +13,11 @@ def create_database():
         with z.open("transitions_parsed.csv") as f:
             transitions = pd.read_csv(f)
 
+    # Ensure the transitions table has a ``score`` column so that the app
+    # can store user provided scores.  When the database is created the
+    # column is initialised with empty strings.
+    transitions["score"] = ""
+
     # Create the SQLite database and write the DataFrame
     conn = sqlite3.connect("rfi.db")
     rfi.to_sql("rfi_table", conn, if_exists="replace", index=True, index_label="frequency")

--- a/queries.py
+++ b/queries.py
@@ -51,3 +51,11 @@ def load_transitions_data(db_path: str = DEFAULT_DB_PATH) -> pd.DataFrame:
     """Load the ``transitions_table`` from the database."""
 
     return load_table("transitions_table", db_path=db_path)
+
+
+def save_transitions_data(df: pd.DataFrame, db_path: str = DEFAULT_DB_PATH) -> None:
+    """Persist ``df`` to the ``transitions_table`` of ``db_path``."""
+
+    with sqlite3.connect(db_path) as conn:
+        df.to_sql("transitions_table", conn, if_exists="replace", index=False)
+


### PR DESCRIPTION
## Summary
- add a score column when the SQLite DB is created
- ensure app doesn't drop the score column when loading transitions
- save updated scores back to the database after editing
- move DB persistence code to `queries.py`

## Testing
- `python -m py_compile app.py create_db.py create_summary_table.py queries.py`
- `python create_db.py` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_685d8ab1a244832dbef135a0a8451ee9