### PR TITLE
Update grid event handling

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,5 @@
 import streamlit as st
+import pandas as pd
 
 from create_db import create_database
 from create_summary_table import create_summary_table
@@ -42,6 +43,11 @@ edited_df = grid_response["data"]
 
 # Extract selected row (if any) and grab the frequency value
 selected_rows = grid_response.get("selected_rows")
+# ``selected_rows`` may be returned as a list of dictionaries.  Convert it to a
+# DataFrame so we can easily access the first selected row, if any.
+if selected_rows is not None:
+    selected_rows = pd.DataFrame(selected_rows)
+
 if selected_rows is not None and not selected_rows.empty:
     selected_frequency = selected_rows.iloc[0]["Frequency (MHz)"]
     # Define an x_range; for instance, +/- 5 around selected frequency:

--- a/editable_tables.py
+++ b/editable_tables.py
@@ -9,7 +9,7 @@ from st_aggrid import (
 
 
 def editable_transitions_table(df: pd.DataFrame) -> dict:
-    """Display an editable AG Grid table for df and return the grid response dict."""
+    """Return a grid widget whose edits and row selections trigger a rerun."""
     row_style = JsCode(
         """
 function(params) {
@@ -42,7 +42,11 @@ function(params) {
     grid_response = AgGrid(
         df,
         gridOptions=grid_options,
-        update_mode=GridUpdateMode.VALUE_CHANGED,
+        # Trigger a rerun whenever either a cell edit or a row selection
+        # modifies the underlying grid model.  ``MODEL_CHANGED`` captures
+        # both VALUE_CHANGED and SELECTION_CHANGED events so the app reacts
+        # immediately to row selections.
+        update_mode=GridUpdateMode.MODEL_CHANGED,
         data_return_mode=DataReturnMode.FILTERED_AND_SORTED,
         allow_unsafe_jscode=True,
     )


### PR DESCRIPTION
## Summary
- trigger reruns when a row is selected by switching `GridUpdateMode` to `MODEL_CHANGED`
- make sure `selected_rows` is interpreted as a DataFrame
- import pandas in `app.py`

## Testing
- `python -m py_compile app.py editable_tables.py queries.py plots.py create_db.py create_summary_table.py`

------
https://chatgpt.com/codex/tasks/task_e_685dab44b118832db7a5f21fd56016c1